### PR TITLE
Use hasOwnProperty to skip prototype properties

### DIFF
--- a/src/angular-router.js
+++ b/src/angular-router.js
@@ -25,6 +25,9 @@
         this.$get = ['routingService', function(routingService) {
             routingService.setPlaceholderPattern('angular');
             for (var i in namedRoutes) {
+                if (!namedRoutes.hasOwnProperty(i)) {
+                    continue;
+                }
                 var namedRoute = namedRoutes[i];
                 routingService.add(namedRoute.name, {
                     path: namedRoute.path


### PR DESCRIPTION
I actually worked on a project where `Array.property` had some added functions. These ended up being adding to the router, resulting in confusing errors.  
A quick `hasOwnProperty()` should do the trick.
